### PR TITLE
adds english and german matrix action hint descriptions, fixes #47

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -602,38 +602,194 @@
       "luxury": "Luxus"
     },
     "matrixaction": {
-      "backdoor_entry": "Hintertür benutzen",
-      "brute_force": "Brute Force",
-      "change_icon": "Icon verändern",
-      "check_os": "Overwatch-Wert best.",
-      "control_device": "Gerät steuern",
-      "crack_file": "Datei Cracken",
-      "crash_program": "Progr. abstürzen l.",
-      "data_spike": "Datenspike",
-      "disarm_data_bomb": "Datenbombe entsch.",
-      "edit_file": "Datei editieren",
-      "encrypt_file": "Datei verschlüsseln",
-      "enter_host": "Host betreten/verlassen",
-      "erase_matrix_signature": "Matrixsign. löschen",
-      "format_device": "Gerät formatieren",
-      "full_matrix_defense": "Volle Matrixabwehr",
-      "hash_check": "Püfsummensuche",
-      "hide": "Verstecken",
-      "jack_out": "Ausstöpseln",
-      "jam_signals": "Signal stören",
-      "jump_rigged": "Hineinspringen",
-      "matrix_perception": "Matrixwahrnehmung",
-      "matrix_search": "Matrixsuche",
-      "probe": "Sondieren",
-      "reboot_device": "Gerät neu starten",
-      "reconfigure": "Matrixattr. austauschen",
-      "send_message": "Nachricht übermitteln",
-      "set_data_bomb": "Datenbombe legen",
-      "snoop": "Übertragung abfang.",
-      "spoof_command": "Befehl vortäuschen",
-      "switch_ifmode": "Interfacemodus wechseln",
-      "tarpit": "Teergrube",
-      "trace_icon": "Icon aufspüren"
+      "backdoor_entry": {
+        "name": "Hintertür benutzen",
+        "hint": "Bekomme auf leise Art Admin Zugriff auf einen Host oder ein Gerät. Führe zuerst erfolgreich eine Sondieren-Aktion aus und addiere dann deine Nettoerfolge als Würfelpoolbonus auf diese Probe.",
+      },
+      "brute_force": {
+        "name": "Brute Force",
+        "hint": "Die Brecheisen-Variante für schnellen Zugriff auf ein Ziel. Wenn du direkt von Gast auf Admin-Zugang wechseln willst, bekommt die Gegenseite zwei Bonuswürfel und plus vier auf den Verteidigungswert - In jedem Fall wird ein Alarm beim Besitzer ausgelöst.",
+      },
+      "calibration": {
+        "name": "Kalibrierung",
+        "hint": "Addiere eins auf das Matrix-Initiativeergebnis von dir und deinen Teammitgliedern (Die einen AR-Feed mit deinem PAN teilen) für je zwei Erfolge. Das Maximum einer Persona ist dein Wert auf Datenverarbeitung.",
+      },
+      "change_icon": {
+        "name": "Icon verändern",
+        "hint": "Ersetze ein Icon mit einem anderen. Das hilft allerdings nicht dabei dein eigenes Icon zu verschleiern, wenn jemand gezielt nach dir sucht.",
+      },
+      "check_os": {
+        "name": "Overwatch-Wert bestimmen",
+        "hint": "Wirf einen Blick auf deinen Overwatch-Wert. Ironischerweise steigt durch diese Handlung dein OW.",
+      },
+      "control_device": {
+        "name": "Gerät steuern",
+        "hint": "Übernimm die Kontrolle über ein Gerät als wärest du der Besitzer, bis du es aus freien Stücken abgibst, es ausschaltest oder jemand anderes dich herauswirft.",
+      },
+      "crack_file": {
+        "name": "Datei cracken",
+        "hint": "Mache mit dieser Aktion eine verschlüsselte Datei wieder lesbar.",
+      },
+      "crash_program": {
+        "name": "Programm abstürzen lassen",
+        "hint": "Nutze eine Matrixwahrnehmung um herauszufinden, welche Programme dein Gegner laufen hat. Dann nutze diese Aktion um es gezielt zum Absturz zu bringen.",
+      },
+      "data_spike": {
+        "name": "Datenspike",
+        "hint": "Die Standardattacke, um Matrixschaden an einem Gerät oder einer Persona zu machen.",
+      },
+      "disarm_data_bomb": {
+        "name": "Datenbombe entschärfen",
+        "hint": "Hiermit kannst du mit Matrixwahrnehmung gefundene Datenbomben entschärfen. Ohne einen Nettoerfolg fliegt dir das Ding um die Ohren.",
+      },
+      "device_lock": {
+        "name": "Gerätesperre",
+        "hint": "Für soviele Kampfrunden wie du Nettoerfolge hattest, kann der Besitzer das Gerät nicht von der Matrix trennen. Kann einmalig durch Abgabe einer Nebenhandlung um eine Kampfrunde verlängert werden.",
+      },
+      "denial_of_service": {
+        "name": "Dienstverweigerung",
+        "hint": "Alle Proben, die mit diesem Wifi-fähigen Gerät ausgeführt werden, bekommen einen Würfelpoolmalus von [Nettoerfolge] mal zwei.",
+      },
+      "delayed_command": {
+        "name": "Verzögerter Befehl",
+        "hint": "Sende einen Befehl mitsamt einer Zeitangabe an ein Gerät. Bei Erfolg sieht es den Befehl als legitim an. Nach Ablauf der Zeit wird der Befehl ausgeführt, auch wenn das Gerät von der Matrix getrennt wurde. Ein vorheriger Neustart löscht den Befehl allerdings.",
+      },
+      "edit_file": {
+        "name": "Datei editieren",
+        "hint": "Erstelle, editiere, kopiere oder lösche eine Datei. Während eines Kampfes kann pro ausgeführter Aktion nur ein Detail geändert werden. Verschlüsselte Dateien können nicht kopiert werden.",
+      },
+      "encrypt_file": {
+        "name": "Datei verschlüsseln",
+        "hint": "Diese Handlung macht eine Datei unlesbar, ohne sie vorherig zu entschlüsseln. Die Verschlüsselungsstufe entspricht der Erfolge bei diesem Wurf.",
+      },
+      "enter_host": {
+        "name": "Host betreten/verlassen",
+        "hint": "Host betreten oder verlassen.",
+      },
+      "erase_matrix_signature": {
+        "name": "Matrixsignatur löschen",
+        "hint": "Wenn du das Attribut Ressonanz hast, kannst du hiermit Matrixspuren eines Technomancers oder Sprites löschen.",
+      },
+      "format_device": {
+        "name": "Gerät formatieren",
+        "hint": "Du ersetzt den Bootsektoreines Geräts mit deinem eigenen Code, sodass es bei einem Neustart nicht mehr hochfährt.",
+      },
+      "full_matrix_defense": {
+        "name": "Volle Matrixabwehr",
+        "hint": "Addiere deinen Wert auf Firewall zu allen Verteidigungsproben in der Matrix.",
+      },
+      "garbage_in_out": {
+        "name": "Garbage In/Garbage Out",
+        "hint": "Spiele mit den Funktionen eines Gerätes herum. Zum Beispiel wird wenn der Benutzer ein Programm starten will stattdessen das zuletzt gemachte Bild gelöscht.",
+      },
+      "hash_check": {
+        "name": "Prüfsummensuche",
+        "hint": "Suche auf einem Host oder Gerät nach einer verschlüsselten Datei mit einem bestimmten Inhalt. Die Chancen steigen nicht unerheblich, wenn du im Vorfeld dafür eine valide Prüfsumme gestellt bekommen hast.",
+      },
+      "hide": {
+        "name": "Verstecken",
+        "hint": "Versuche, einen Verfolger in der Matrix abzuschütteln. Funktioniert nicht, wenn dieser User- oder Adminrechte auf einem deiner Geräte hat.",
+      },
+      "jack_out": {
+        "name": "Ausstöpseln",
+        "hint": "Entkoppel dich von der Matrix durch einen Neustart deines Geräts. Bei einer Linksperre ist es eine vergleichende Probe. Bist du vorher nicht auf AR gewechselt, erleidest du Auswurfschock.",
+      },
+      "jam_signals": {
+        "name": "Signal stören",
+        "hint": "Solange du dein Gerät nicht anderweitig nutzt, sendet es ein Rauschen in der Höhe deiner Erfolge innerhalb 100 Metern aus.",
+      },
+      "jump_rigged": {
+        "name": "Hineinspringen",
+        "hint": "Das Fahrzeug oder die Drone braucht ein Riggerinterface, niemand anders darf bereits hineingesprungen sein und du brauchst eine Riggerkonsole. Abhängig davon ob du der Besitzer bist und welche Zugangsberechtigungen du hast, musst du eventuell würfeln.",
+      },
+      "known_exploit": {
+        "name": "Hintertür mit bekanntem Exploit benutzen",
+        "hint": "Du versuchst, bekannte Fehler zu Nutzen um Admin zu werden. Deine Chancen sinken auf gut gewarteten Hosts und Geräten. Dies kombiniert die Sondieren- und Hintertür benutzen Aktionen, du kannst allerdings hierfür kein Edge erhalten oder ausgeben während die Gegenseite gratis ein temporäres Edge bekommt.",
+      },
+      "masquerade": {
+        "name": "Maskerade",
+        "hint": "Gib für [Nettoerfolge] Kampfrunden aus, in der Matrix jemand anders zu sein. Die Matrix lässt sich allerdings nicht einfach überlisten, sodass du damit nicht einfach der Eigentümer von Geräten werden oder Banking betreiben kannst.",
+      },
+      "matrix_perception": {
+        "name": "Matrixwahrnehmung",
+        "hint": "Finde ein Icon auf Schleichfahrt oder sammel Informationen über ein Ziel, sein Icon und Gerätestufe, laufende Geräte, Programme sowie speziellere Informationen.",
+      },
+      "matrix_search": {
+        "name": "Matrixsuche",
+        "hint": "Scanne die öffentliche Matrix nach Informationen über ein Subjekt.",
+      },
+      "metahuman_middle": {
+        "name": "Mittelsmetamensch",
+        "hint": "Die gesamte Kommunikation und Matrixhandlungen des Ziels laufen für [Nettoerfolge] Runden über dein Gerät.",
+      },
+      "modify_icon": {
+        "name": "Icon modifizieren",
+        "hint": "Modeliere ein Icon, zu dem du Adminzugriff hast, um zu etwas, das es nicht repräsentiert. Zum Beispiel sieht danach das Icon deiner Waffe aus wie Blumen.",
+      },
+      "probe": {
+        "name": "Sondieren",
+        "hint": "Versuche, Schwachstellen zu finden um sie später als Hintertür zu benutzen. Dies braucht seine Zeit, alarmiert im Gegensatz zu Brute Force allerdings nicht das Ziel.",
+      },
+      "pop_up": {
+        "name": "Pop-Up",
+        "hint": "Überschwämme dein Gegenüber mit ARO Fenstern, sodass er für [Nettoerfolge] Runden kein Edge ausgeben kann.",
+      },
+      "reboot_device": {
+        "name": "Gerät neu starten",
+        "hint": "Schneide ein Gerät vom Zugang zur Matrix ab, indem es neu startet. Am Ende der folgenden Kampfrunde ist es wieder online.",
+      },
+      "reconfigure": {
+        "name": "Matrixattribute austauschen",
+        "hint": "Vertausche zwei Matrixattribute deiner Matrix Persona, egal von welcher Quelle (Kommlink, Cyberbuchse, ...) sie kommen.",
+      },
+      "send_message": {
+        "name": "Nachricht übermitteln",
+        "hint": "Versende eine Audio oder Textnachricht oder starte eine Live-Übertragung.",
+      },
+      "set_data_bomb": {
+        "name": "Datenbombe legen",
+        "hint": "Klebe eine Datenbombe an eine Datei, um sorglose Hacker virtuell in die Luft zu jagen. Die Stufe kann maximal deinen Nettoerfolgen entsprechen. Wähle dann, ob die Bombe auch die Datei zerstört oder nicht.",
+      },
+      "snoop": {
+        "name": "Übertragung abfangen",
+        "hint": "Bekomme Zugriff auf den Datenverkehr zwischen dem Ziel und der Matrix.",
+      },
+      "spoof_command": {
+        "name": "Befehl vortäuschen",
+        "hint": "Sende einen Befehl an ein Gerät, der vorgibt vom Besitzer verschickt worden zu sein.",
+      },
+      "squelch": {
+        "name": "Ersticken",
+        "hint": "Verhindere, dass das Ziel für [Nettoerfolge] Kampfrunden Nachrichten verschicken oder jemanden anrufen kann.",
+      },
+      "subvert_infrastructure": {
+        "name": "Infrastruktur unterwandern",
+        "hint": "Versetze dich durch diese Handlung in die Lage einer Gruppe ähnlicher, einfacher Wifigeräte eines Hosts einfache Befehle zu schicken. Damit kannst du zum Beispiel Straßenlaternen ausschalten oder alle Sicherheitskameras nach links drehen.",
+      },
+      "switch_ifmode": {
+        "name": "Interfacemodus wechseln",
+        "hint": "Wechsel zwischen dem AR und dem VR Modus deines Interfaces.",
+      },
+      "tarpit": {
+        "name": "Teergrube",
+        "hint": "Verlangsame dein Ziel, indem du ihm etwas Schaden machst und seine Datenverarbeitung senkst.",
+      },
+      "threat_analysis": {
+        "name": "Bedrohungsanalyse",
+        "hint": "Markiere schädliche Ziele und teile diese per AR Feed mit deinen Kumpanen, sodass diese deine Erfolge als Würfelpoolbonus bei ihren Verteidigungswürfen bekommen. Funktioniert sowohl in der physischen Welt wie in der Matrix.",
+      },
+      "trace_icon": {
+        "name": "Icon aufspüren",
+        "hint": "Mache den physischen Ort eines Gerätes oder einer Persona ausfindig.",
+      },
+      "virtual_aim": {
+        "name": "Virtuelles Zielen",
+        "hint": "Gibt dir einen Bonuswürfel für Angriffe wie Datenspike oder Teergrube. Einmal pro Runde ausführbar, addiert aber jede Runde auf, bis du keine Aktion Virtuelles Zielen mehr in einer Runde ausführst oder attackierst. Der Maximale Bonus entspricht deiner Willenskraft.",
+      },
+      "watchdog": {
+        "name": "Stalking",
+        "hint": "Erlaubt dir, während [Nettoerfolge] Runden die Handlungen einer Matrix Persona oder einem Gerät zu verfolgen, antizipieren und unterbechen. Außerdem kannst du, während Stalking läuft, eine Bedrohungsanalyse als Nebenhandlung ausführen.",
+      },
     },
     "monitor": {
       "matrix": "Matrix",

--- a/lang/en.json
+++ b/lang/en.json
@@ -620,53 +620,194 @@
       }
     },
     "matrixaction": {
-      "backdoor_entry": "Backdoor Entry",
-      "brute_force": "Brute Force",
-      "calibration": "Calibration",
-      "change_icon": "Change Icon",
-      "check_os": "Check OS",
-      "control_device": "Control Device",
-      "crack_file": "Crack File",
-      "crash_program": "Crash Program",
-      "data_spike": "Dataspike",
-      "disarm_data_bomb": "Disarm Data Bomb",
-      "device_lock": "Device Lock",
-      "denial_of_service": "Denial of Service",
-      "delayed_command": "Delayed Command",
-      "edit_file": "Edit File",
-      "encrypt_file": "Encrypt File",
-      "enter_host": "Enter Host",
-      "erase_matrix_signature": "Erase Matrix Sign.",
-      "format_device": "Format Device",
-      "full_matrix_defense": "Full Matrix Defense",
-      "garbage_in_out": "Garbage In/Garbage Out",
-      "hash_check": "Hash Check",
-      "hide": "Hide",
-      "jack_out": "Jack Out",
-      "jam_signals": "Jam Signals",
-      "jump_rigged": "Jump Into Rigged Device",
-      "known_exploit": "Known Exploit Backdoor Entry",
-      "masquerade": "Masquerade",
-      "matrix_perception": "Matrix Perception",
-      "matrix_search": "Matrix Search",
-      "metahuman_middle": "Metahuman in the Middle",
-      "modify_icon": "Modify Icon",
-      "probe": "Probe",
-      "pop_up": "Popup",
-      "reboot_device": "Reboot Device",
-      "reconfigure": "Reconfigure Matrix Attribute",
-      "send_message": "Send Message",
-      "set_data_bomb": "Set Data Bomb",
-      "snoop": "Snoop",
-      "spoof_command": "Spoof Command",
-      "squelch": "Squelch",
-      "subvert_infrastructure": "Subvert Infrastructure",
-      "switch_ifmode": "Switch Interface Mode",
-      "tarpit": "Tarpit",
-      "threat_analysis": "Threat Analysis",
-      "trace_icon": "Trace Icon",
-      "virtual_aim": "Virtual Aim",
-      "watchdog": "Watchdog"
+      "backdoor_entry": {
+        "name": "Backdoor Entry",
+        "hint": "Gain Admin access to a host or device the sneaky way. First, do a successful Probe action and add the net hits as a bonus to this dice pool.",
+      },
+      "brute_force": {
+        "name": "Brute Force",
+        "hint": "Attempt to get quick access by spaming a target. When trying to switch from outsider to admin directly the enemy gets two bonus dice and plus four Defense Rating - In any way the device will be alarmed.",
+      },
+      "calibration": {
+        "name": "Calibration",
+        "hint": "Add one to the Matrix Initiative of you and your team mates (sharing an AR-feed with your PAN) for every two hits you get. The total increase of a Persona can't be higher than your Data Processing.",
+      },
+      "change_icon": {
+        "name": "Change Icon",
+        "hint": "Select an Icon and replace it with another one. This however won't help you not get tracked down, if someone is willing to.",
+      },
+      "check_os": {
+        "name": "Check OS",
+        "hint": "Have a look at your Overwatch Score. Ironically this action increases your OS.",
+      },
+      "control_device": {
+        "name": "Control Device",
+        "hint": "Take control of a device as if you are the owner, until you leave the device willingly, shut it down or someone else pushes you out of control.",
+      },
+      "crack_file": {
+        "name": "Crack File",
+        "hint": "Make an encrypted file readable with this action.",
+      },
+      "crash_program": {
+        "name": "Crash Program",
+        "hint": "Check out what programs your opponent's device is running with a Matrix Perception, then take this action to shut it down.",
+      },
+      "data_spike": {
+        "name": "Dataspike",
+        "hint": "This is the standard attack for dealing Matrix damage to a device or persona.",
+      },
+      "disarm_data_bomb": {
+        "name": "Disarm Data Bomb",
+        "hint": "With this, you can disarm Data Bombs that you detected with Matrix Perception. If you fail to achieve net hits, the Data Bomb blows up.",
+      },
+      "device_lock": {
+        "name": "Device Lock",
+        "hint": "Prevent the owner of a device to cut off the connection of a device to the Matrix for the duration of net hit combat rounds. Can be prolonged one time by spending a minor action.",
+      },
+      "denial_of_service": {
+        "name": "Denial of Service",
+        "hint": "Create a dice penalty for all tests using this wifi device by net hits times two.",
+      },
+      "delayed_command": {
+        "name": "Delayed Command",
+        "hint": "Send a command to a device with a time frame. On success, the device will acknowledge it as being sent from it's owner. After the time frame expired, the command will,be executed, even when the device was cut off from the Matrix. A reboot before execution however will delete the command.",
+      },
+      "edit_file": {
+        "name": "Edit File",
+        "hint": "Add, edit, copy or delete a file with this action. During a combat however, adding or changing a file needs one action per detail. Encrypted files can't be copied.",
+      },
+      "encrypt_file": {
+        "name": "Encrypt File",
+        "hint": "This makes a file unreadable without decrypting it first. The Encryption Rating is equal to the hits of this roll.",
+      },
+      "enter_host": {
+        "name": "Enter/Exit Host",
+        "hint": "Get into or leave a host.",
+      },
+      "erase_matrix_signature": {
+        "name": "Erase Matrix Sign",
+        "hint": "If you have a Resonance rating, remove a Matrix signature left by a technomancer or sprite with this action.",
+      },
+      "format_device": {
+        "name": "Format Device",
+        "hint": "You replace the boot sector of this device with your own code, so it won't start anymore whenever it is told to reboot.",
+      },
+      "full_matrix_defense": {
+        "name": "Full Matrix Defense",
+        "hint": "Add your Firewall to all defense tests that are related to the Matrix.",
+      },
+      "garbage_in_out": {
+        "name": "Garbage In/Garbage Out",
+        "hint": "Mess around with the input and output signals of a device. For example, every time the owner wants to start a program, the last taken picture is deleted instead.",
+      },
+      "hash_check": {
+        "name": "Hash Check",
+        "hint": "Search for encrypted files with a specific content in a host or device. Chances increase significantly by having a hash value.",
+      },
+      "hide": {
+        "name": "Hide",
+        "hint": "Try to make a target lose sight to you in the Matrix. Does not work if the icon has User or Admin access to any device of your network.",
+      },
+      "jack_out": {
+        "name": "Jack Out",
+        "hint": "Disconnect from the Matrix by rebooting your device. If you are link-locked, the opponent will roll against you. If you did not switch to AR first, you'll get damage by dump-shock.",
+      },
+      "jam_signals": {
+        "name": "Jam Signals",
+        "hint": "While you are not using this device for other actions, this will increase the noise rating by any hits you have within a range of 100 meters.",
+      },
+      "jump_rigged": {
+        "name": "Jump Into Rigged Device",
+        "hint": "The vehicle or drone you want to jump into needs a rigger adaption, nobody is jumped into it right now and you need a control rig. Your ownership and access level also factor in if this will work or not and if you need to roll.",
+      },
+      "known_exploit": {
+        "name": "Known Exploit Backdoor Entry",
+        "hint": "Try to use known exploits to get direct Admin access. Your chance of succeeding is decreased on well patched hosts or devices. This combines the Probe and Backdoor Entry actions to one, however you can't get or use Edge for this while the opponent gets one temporary Edge for free to thwart your intentions.",
+      },
+      "masquerade": {
+        "name": "Masquerade",
+        "hint": "You can pretend being someone else in the Matrix for net hit minutes. However it's hard to trick the Matrix and this won't work for things like taking ownership of devices or banking.",
+      },
+      "matrix_perception": {
+        "name": "Matrix Perception",
+        "hint": "Find an icon that runs silent or collect information about a target, it's icon and device rating, running devices, programs and other specific information.",
+      },
+      "matrix_search": {
+        "name": "Matrix Search",
+        "hint": "Scan the public Matrix for information about a subject.",
+      },
+      "metahuman_middle": {
+        "name": "Metahuman in the Middle",
+        "hint": "Make all Matrix communications and actions run through your device for net hit minutes.",
+      },
+      "modify_icon": {
+        "name": "Modify Icon",
+        "hint": "Modify an Icon that you have Admin access for to something, that it does not represent, like making your gun look like flowers.",
+      },
+      "probe": {
+        "name": "Probe",
+        "hint": "Try to find an exploit and use the Backdoor Entry action afterwards to get access. This takes some time, but in contrast to Brute Force, this won't alarm the target.",
+      },
+      "pop_up": {
+        "name": "Popup",
+        "hint": "Spam your opponent with ARO windows, so he can't spend Edge for net hit rounds.",
+      },
+      "reboot_device": {
+        "name": "Reboot Device",
+        "hint": "This will cut off a device from the Matrix by forcing it to reboot. It will be online again by the end of the following combat round.",
+      },
+      "reconfigure": {
+        "name": "Reconfigure Matrix Attribute",
+        "hint": "Switch two base ratings from your Matrix Persona, regardless of the source (commlink, cyberjack, ...) they are coming from.",
+      },
+      "send_message": {
+        "name": "Send Message",
+        "hint": "Deliver audio or text to somebody else or create a live feed for them.",
+      },
+      "set_data_bomb": {
+        "name": "Set Data Bomb",
+        "hint": "Attach a Data Bomb to blow up careless hackers. The rating can be up to the maximum net hits you got. Then choose, if the Data Bomb deletes the file or not.",
+      },
+      "snoop": {
+        "name": "Snoop",
+        "hint": "Get your hands on data traffic that is exchanged between your target and the Matrix.",
+      },
+      "spoof_command": {
+        "name": "Spoof Command",
+        "hint": "Send a command to a device pretending that you are the legitimate owner.",
+      },
+      "squelch": {
+        "name": "Squelch",
+        "hint": "Hinder the target from sending messages or calling someone for net hit rounds.",
+      },
+      "subvert_infrastructure": {
+        "name": "Subvert Infrastructure",
+        "hint": "Make a group of similar, simple wifi devices of one host do what you want, like turning off street lights or rotate all security cameras to the left.",
+      },
+      "switch_ifmode": {
+        "name": "Switch Interface Mode",
+        "hint": "Toggle between the AR and VR mode of your interface.",
+      },
+      "tarpit": {
+        "name": "Tarpit",
+        "hint": "Slow down your target by making some damage and reducing it's data processing value.",
+      },
+      "threat_analysis": {
+        "name": "Threat Analysis",
+        "hint": "Mark harmfull entities and share them by AR Feed to your team mates, so they get your succcesses as bonus dice on their defense roll. Works for the physical world as well as for the Matrix.",
+      },
+      "trace_icon": {
+        "name": "Trace Icon",
+        "hint": "Track down the physical location of a device or persona.",
+      },
+      "virtual_aim": {
+        "name": "Virtual Aim",
+        "hint": "Gives you one bonus dice for your attack actions like Data Spike or Tarpit. Can be activated once per round, but sums up each round unless you don't do another Virtual Aim action or attack. Maximum is your Willpower.",
+      },
+      "watchdog": {
+        "name": "Watchdog",
+        "hint": "Allows you to stalk and anticipate the actions of a Matrix persona or device during net hit rounds, so that you can intervene. Having the Watchdog active allows you to execute the Threat Analysis as a minor action.",
+      },
     },
     "matrixini": {
 			"ar": "AR",


### PR DESCRIPTION
The translations have been made by re-phrasing the rules of the english SR6 - Berlin Edition rulebook, the german rulebook and the german Hack & Slash variant.