### PR TITLE
Fixed bug preventing roll dialog to open on custom rolls

### DIFF
--- a/module/Rolls.js
+++ b/module/Rolls.js
@@ -125,7 +125,8 @@ async function _showRollDialog(data) {
         };
 
         const html = await renderTemplate(template, dialogData);
-        const title = data.title ? data.actor.name + ': ' + data.title : data.actor.name + ': Roll Dialog';
+        const rollTitle = data.title ? data.title : 'Roll Dialog';
+        const title = data.actor ? data.actor.name + ': ' + rollTitle : rollTitle;
         // Also prepare a ConfiguredRoll
         console.log("SR6E | ###Create ConfiguredRoll");
         let dialogResult = new ConfiguredRoll();


### PR DESCRIPTION
Fixed a bug where you can't open the roll dialog with the dice-button above the chat window.
![grafik](https://github.com/user-attachments/assets/b340fb57-0072-4055-8c40-ac52bcf6e549)
 