### PR TITLE
Fixed bug where vehicles/drones can't be targeted

### DIFF
--- a/templates/parts/vehicle-piloting.html
+++ b/templates/parts/vehicle-piloting.html
@@ -38,7 +38,7 @@
           <label class="skill-value skill-key rollable skill-name skill-roll">{{localize "shadowrun6.derived.defense_rating" }}</label>
         </td>
         <td class="skill-pool">
-          {{system.dr.pool}}
+          {{system.defenserating.physical.pool}}
         </td>
         <td>&nbsp;</td>
       </tr>


### PR DESCRIPTION
When targeting a vehicle and starting a weapon roll, the roll dialog would not open because the vehicles/drones didn't have the ``system.defenserating.physical`` properties.