### PR TITLE
Add Matrix Monitor for device damage

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -1038,6 +1038,7 @@
       "configure": "Justiere deinen Wurf",
       "wound-modifier": "Verwende Wundabzug",
       "sustained-spell-modifier": "Abzug durch aufr. Zauber",
+      "matrix-modifier": "Verwende Matrixabzug",
       "criticalglitch": "Kritischer Patzer",
       "heal_apply": "Heilung wirken",
       "damage": "Schaden: ",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1072,6 +1072,7 @@
       "configure": "Configure your roll",
       "wound-modifier": "Use wound modifier",
       "sustained-spell-modifier": "Use sustained spell modifier",
+      "matrix-modifier": "Use matrix modifier",
       "criticalglitch": "Critical glitch",
       "heal_apply": "Heal",
       "damage": "Damage: ",

--- a/module/RollDialog.js
+++ b/module/RollDialog.js
@@ -100,6 +100,7 @@ export class RollDialog extends Dialog {
         // React to Modifier checkboxes
         html.find("#useWoundModifier").change(this._updateDicePool.bind(this));
         html.find("#useSustainedSpellModifier").change(this._updateDicePool.bind(this));
+        html.find("#useMatrixModifier").change(this._updateDicePool.bind(this));
         // React to change in modifier
         html.find("#modifier").change(this._updateDicePool.bind(this));
         // Show Threshold and Interval fields when extended tests is enabled.
@@ -381,15 +382,17 @@ export class RollDialog extends Dialog {
         // Get the value of the checkbox if the calculated wound penality should be used
         let useWoundModifier = document.getElementById("useWoundModifier").checked;
         let useSustainModifier = document.getElementById("useSustainedSpellModifier").checked;
+        let useMatrixModifier = document.getElementById("useMatrixModifier").checked;
 
         // Calculate new sum
         console.log("SR6E | updateDicePool: ", this);
         let woundMod = (this.actor) ? this.actor.getWoundModifier() : 0;
         let sustainedMod = (this.actor) ? this.actor.getSustainedSpellsModifier() : 0;
+        let matrixMod = (this.actor) ? this.actor.getMatrixModifier() : 0;
         if (this.actor) {
-            console.log("SR6E | updateDicePool2: ", this.prepared.pool, this.modifier, woundMod, sustainedMod);
+            console.log("SR6E | updateDicePool2: ", this.prepared.pool, this.modifier, woundMod, sustainedMod, matrixMod);
         }
-        this.prepared.calcPool = this.prepared.pool + this.modifier - (useWoundModifier?woundMod:0) - (useSustainModifier?sustainedMod:0);
+        this.prepared.calcPool = this.prepared.pool + this.modifier - (useWoundModifier?woundMod:0) - (useSustainModifier?sustainedMod:0) - (useMatrixModifier?matrixMod:0);
         this.prepared.checkHardDiceCap();
         $("label[name='dicePool']")[0].innerText = this.prepared.calcPool.toString();
     }

--- a/module/Rolls.js
+++ b/module/Rolls.js
@@ -66,6 +66,7 @@ async function _showRollDialog(data) {
             if (data.actor) {
                 data.useWoundModifier = data.dialogConfig?.useWoundModifier === false ? false : true;
                 data.useSustainedSpellModifier = data.dialogConfig?.useSustainedSpellModifier === false ? false : true;
+                data.useMatrixModifier = data.dialogConfig?.useMatrixModifier === false ? false : true;
 
                 // Don't use wound modifier on Resist Damage tests
                 if (data.rollType == RollType.Soak) {
@@ -76,9 +77,14 @@ async function _showRollDialog(data) {
                 if (data.actionText.substring(0,6) == 'Resist') {
                     data.useSustainedSpellModifier = false;
                 }
-                
+                // Only use matrix modifier on matrix actions
+                if (data.rollType != RollType.MatrixAction) {
+                    data.useMatrixModifier = false;
+                }
+
                 data.calcPool -= (data.useWoundModifier             ? data.actor.getWoundModifier() : 0);
                 data.calcPool -= (data.useSustainedSpellModifier    ? data.actor.getSustainedSpellsModifier() : 0);
+                data.calcPool -= (data.useMatrixModifier            ? data.actor.getMatrixModifier() : 0);
             }
         }
         /*

--- a/module/Shadowrun6.js
+++ b/module/Shadowrun6.js
@@ -454,7 +454,8 @@ Hooks.once("init", async function () {
                     extendedRoll.timePassed = parseInt(dataset.timePassed);
                     dialogConfig = {
                         useWoundModifier: false,
-                        useSustainedSpellModifier: false
+                        useSustainedSpellModifier: false,
+                        useMatrixModifier: false
                     };
                     actor.rollCommonCheck(extendedRoll, dialogConfig);
 
@@ -471,7 +472,8 @@ Hooks.once("init", async function () {
                     loyaltyRoll.legwork = { legworkResult: parseInt(dataset.legworkResult) };
                     dialogConfig = {
                         useWoundModifier: false,
-                        useSustainedSpellModifier: false
+                        useSustainedSpellModifier: false,
+                        useMatrixModifier: false
                     };
                     actor.rollCommonCheck(loyaltyRoll, dialogConfig);
                     break;

--- a/module/applications/sheets/SR6ActorSheet.js
+++ b/module/applications/sheets/SR6ActorSheet.js
@@ -732,7 +732,8 @@ export default class Shadowrun6ActorSheet extends ActorSheet {
             }
             dialogConfig = {
                 useModifier: !(rollId === 'damage_physical' || rollId === 'damage_astral'), 
-                useThreshold: false
+                useThreshold: false,
+                useMatrixModifier: false
             };
         }
         else if (classList.includes("attributeonly-roll")) {
@@ -742,7 +743,8 @@ export default class Shadowrun6ActorSheet extends ActorSheet {
             roll.checkText = roll.actionText;
             dialogConfig = {
                 useModifier: true,
-                useThreshold: true
+                useThreshold: true,
+                usingMatrixModifier: false
             };
         }
         else if (rollId = "legwork") {
@@ -757,7 +759,8 @@ export default class Shadowrun6ActorSheet extends ActorSheet {
                 roll.checkText = game.i18n.format("shadowrun6.legwork.loyalty_description", { name: data.contact });
             dialogConfig = {
                 useWoundModifier: false,
-                useSustainedSpellModifier: false
+                useSustainedSpellModifier: false,
+                useMatrixModifier: false
             };
         }
         else {
@@ -765,7 +768,8 @@ export default class Shadowrun6ActorSheet extends ActorSheet {
             roll.useWildDie = 1;
             dialogConfig = {
                 useModifier: true,
-                useThreshold: true
+                useThreshold: true,
+                useMatrixModifier: rollId === "matrix_action" ? true : false
             };
         }
         //TODO dialogConfig.useModifier and useThreshold aren't used in Rolls._showRollDialog

--- a/module/applications/sheets/SR6ActorSheet.js
+++ b/module/applications/sheets/SR6ActorSheet.js
@@ -100,7 +100,7 @@ export default class Shadowrun6ActorSheet extends ActorSheet {
             html.find(".weapon-ammo-reload").click(this._onWeaponAmmoReload.bind(this));
             html.find(".health-phys").on("input", this._redrawBar(html, "Phy", getSystemData(this.actor).physical));
             html.find(".health-stun").on("input", this._redrawBar(html, "Stun", getSystemData(this.actor).stun));
-            html.find(".health-matrix").on("input", this._redrawBar(html, "Matrix", getSystemData(this.actor).persona.monitor));
+            html.find(".health-matrix").on("input", this._redrawBar(html, "Matrix", getSystemData(this.actor).persona?.monitor));
             // Roll Skill Checks
             html.find(".skill-roll").click(this._onRollSkillCheck.bind(this));
             html.find(".spell-roll").click(this._onRollSpellCheck.bind(this));

--- a/module/applications/sheets/SR6ActorSheet.js
+++ b/module/applications/sheets/SR6ActorSheet.js
@@ -90,6 +90,7 @@ export default class Shadowrun6ActorSheet extends ActorSheet {
             html.find(".weapon-ammo-reload").click(this._onWeaponAmmoReload.bind(this));
             html.find(".health-phys").on("input", this._redrawBar(html, "Phy", getSystemData(this.actor).physical));
             html.find(".health-stun").on("input", this._redrawBar(html, "Stun", getSystemData(this.actor).stun));
+            html.find(".health-matrix").on("input", this._redrawBar(html, "Matrix", getSystemData(this.actor).persona.monitor));
             // Roll Skill Checks
             html.find(".skill-roll").click(this._onRollSkillCheck.bind(this));
             html.find(".spell-roll").click(this._onRollSpellCheck.bind(this));
@@ -199,6 +200,11 @@ export default class Shadowrun6ActorSheet extends ActorSheet {
                     // Send monitor change to the right place
                     if (field === "system.physical.dmg" || field === "system.stun.dmg") {
                         const monitorType = field.split('.').at(1);
+                        console.log("SR6E | Updating actor field " + field + ", so setting damage to monitor " + monitorType + " to " + value);
+                        await this.actor.applyDamage(monitorType, null, value);
+                        return;
+                    } else if (field === "system.persona.monitor.dmg") {
+                        const monitorType = "persona.monitor";
                         console.log("SR6E | Updating actor field " + field + ", so setting damage to monitor " + monitorType + " to " + value);
                         await this.actor.applyDamage(monitorType, null, value);
                         return;
@@ -529,41 +535,49 @@ export default class Shadowrun6ActorSheet extends ActorSheet {
         if (!isLifeform(getSystemData(this.actor)) && !this.actor.type == "Vehicle")
             return;
         console.log("SR6E | setDamage", monitorType, damageClicked, monitorAttributes);
-        // if (!event.currentTarget.dataset.value)
-        //     event.currentTarget.dataset.value = 0;
-        // switch (event.target.parentNode.getAttribute("id")) {
+        let key = "";
         switch (monitorType) {
             case "Phy":
-                console.log("SR6E | setDamage physical health to ", damageClicked);
-                //Allow setting zero health by clicking again
-                if (getSystemData(this.actor).physical.dmg == damageClicked) {
-                    await this.actor.update({ [`system.physical.dmg`]: damageClicked - 1 });
-                }
-                //When going health back up, UX is more logical to gain health until the box you clicked on
-                else if (getSystemData(this.actor).physical.dmg > damageClicked) {
-                    await this.actor.update({ [`system.physical.dmg`]: damageClicked - 1 });
-                } 
-                else {
-                    await this.actor.update({ [`system.physical.dmg`]: damageClicked });
-                }
+                key = "physical";
                 break;
             case "Stun":
-                console.log("SR6E | setDamage stun health to ", damageClicked);
-                //Allow setting zero health by clicking again
-                if (getSystemData(this.actor).stun.dmg == damageClicked) {
-                    await this.actor.update({ [`system.stun.dmg`]: damageClicked - 1 });
-                }
-                //When going health back up, UX is more logical to gain health until the box you clicked on
-                else if (getSystemData(this.actor).stun.dmg > damageClicked) {
-                    await this.actor.update({ [`system.stun.dmg`]: damageClicked - 1 });
-                } 
-                else {
-                    await this.actor.update({ [`system.stun.dmg`]: damageClicked });
-                }
+                key = "stun";
+                break;
+            case "Matrix":
+                key = "persona.monitor";
                 break;
         }
+        await this._applyDamage(damageClicked, monitorAttributes, key);
         this.actor.checkUnconscious();
     }
+
+    async _applyDamage(damageClicked, monitorAttributes, key) {
+        console.log("SR6E | _applyDamage", damageClicked, monitorAttributes, key);
+        console.log("SR6E | _applyDamage actor", this.actor);
+        let damage = damageClicked;
+        if (monitorAttributes.dmg == damageClicked) {
+            damage = damageClicked - 1;
+        }
+        //When going health back up, UX is more logical to gain health until the box you clicked on
+        else if (monitorAttributes.dmg > damageClicked) {
+            damage = damageClicked - 1;
+        }
+        await this.actor.update({ [`system.${key}.dmg`]: damage });
+
+        // check if the damage should also be applied to an item
+        if (monitorAttributes.item != undefined && monitorAttributes.item != null) {
+            console.log("SR6E | _applyDamage: also apply damage to item ", monitorAttributes.item);
+            let item = this.actor.items.find(i => i.id === monitorAttributes.item);
+            if (item) {
+                console.log("SR6E | _applyDamage: item found, updating damage");
+                await item.update({ ["dmg"]: damage });
+            } else {
+                console.warn("SR6E | _applyDamage: item not found, cannot update damage");
+            }
+        }
+    }
+
+
     //-----------------------------------------------------
     _redrawBar(html, monitorType, monitorAttributes) {
         console.log("SR6E | _redrawBar ", monitorType, monitorAttributes);
@@ -591,7 +605,7 @@ export default class Shadowrun6ActorSheet extends ActorSheet {
                 i++;
                 let divMonitorBox = document.createElement("div");
                 let divBoxText = document.createElement("div");
-                let breakHr = document.createElement("hr");
+                //let breakHr = document.createElement("hr");
                 let text;
                 if (i === monitorAttributes.max && (i % 3) === (monitorAttributes.max % 3) ) {
                     let minus = -1 * Math.ceil(i / 3);

--- a/module/applications/sheets/SR6ActorSheet.js
+++ b/module/applications/sheets/SR6ActorSheet.js
@@ -562,18 +562,19 @@ export default class Shadowrun6ActorSheet extends ActorSheet {
         else if (monitorAttributes.dmg > damageClicked) {
             damage = damageClicked - 1;
         }
-        await this.actor.update({ [`system.${key}.dmg`]: damage });
 
         // check if the damage should also be applied to an item
         if (monitorAttributes.item != undefined && monitorAttributes.item != null) {
             console.log("SR6E | _applyDamage: also apply damage to item ", monitorAttributes.item);
-            let item = this.actor.items.find(i => i.id === monitorAttributes.item);
+            let item = this.actor.items.get(monitorAttributes.item);
             if (item) {
-                console.log("SR6E | _applyDamage: item found, updating damage");
-                await item.update({ ["dmg"]: damage });
+                console.log("SR6E | _applyDamage: item found, updating damage", item);
+                await item.update({ ["system.dmg"]: damage });
             } else {
                 console.warn("SR6E | _applyDamage: item not found, cannot update damage");
             }
+        } else {
+            await this.actor.update({ [`system.${key}.dmg`]: damage });
         }
     }
 

--- a/module/documents/actor.js
+++ b/module/documents/actor.js
@@ -1430,7 +1430,10 @@ export default class Shadowrun6Actor extends Actor {
         system.persona.device.base.s = 0;
         system.persona.device.base.d = 0;
         system.persona.device.base.f = 0;
+
+        let active_device = null;
         actorData.items.forEach((tmpItem) => {
+            const tmp_id = tmpItem._id;
             const systemItem = getSystemData(tmpItem);
             if (tmpItem.type == "gear" && isMatrixDevice(systemItem)) {
                 let item = getSystemData(tmpItem);
@@ -1438,9 +1441,8 @@ export default class Shadowrun6Actor extends Actor {
                     if (item.usedForPool) {
                         system.persona.device.base.d = parseInt(item.d);
                         system.persona.device.base.f = parseInt(item.f);
-                        if (!system.persona.monitor.max) {
-                            system.persona.monitor.max = Math.ceil(parseInt(item.subtype == "COMMLINK" ? item.devRating : item.devRating) / 2) + 8;
-                            system.persona.monitor.item = systemItem._id;
+                        if (active_device == null) {
+                            active_device = tmp_id;
                         }
                     }
                 }
@@ -1448,13 +1450,26 @@ export default class Shadowrun6Actor extends Actor {
                     if (item.usedForPool) {
                         system.persona.device.base.a = (item.a);
                         system.persona.device.base.s = (item.s);
-                        system.persona.monitor.max = Math.ceil(parseInt(item.devRating) / 2) + 8;
-                        system.persona.monitor.item = systemItem._id;
-                        console.log("SR6E | attached item", systemItem, item);
+                        active_device = tmp_id;
                     }
                 }
             }
         });
+        if (active_device) {
+            const tmp_device = getSystemData(actorData.items.get(active_device));
+            system.persona.monitor.max = Math.ceil(parseInt(tmp_device.devRating) / 2) + 8;
+            system.persona.monitor.dmg = tmp_device.dmg;
+            system.persona.monitor.value = system.persona.monitor.max - system.persona.monitor.dmg;
+            system.persona.monitor.item = active_device;
+            console.log("SR6E | attached item", tmp_device);
+        } else {
+            system.persona.monitor.max = 0;
+            system.persona.monitor.dmg = 0;
+            system.persona.monitor.value = 0;
+            system.persona.monitor.item = null;
+            console.log("SR6E | no active device found");
+        }
+
         console.log("SR6E | preparePersona: device=", system.persona.device);
         // Living persona
         if (system.mortype == "technomancer") {

--- a/module/documents/actor.js
+++ b/module/documents/actor.js
@@ -1541,6 +1541,14 @@ export default class Shadowrun6Actor extends Actor {
         return woundModifier;
     }
     //---------------------------------------------------------
+    getMatrixModifier() {
+        const data = getSystemData(this);
+        let matrixModifier = this._getWoundModifierPerMonitor(data.persona.monitor);
+        /* Return the combined penalties from matrix damage */
+        console.log("SR6E | Current Matrix Penalties: " + matrixModifier);
+        return matrixModifier;
+    }
+    //---------------------------------------------------------
     getSustainedSpellsModifier() {
         const actorData = getActorData(this);
         const items = actorData.items;

--- a/styles/layout.css
+++ b/styles/layout.css
@@ -173,6 +173,16 @@ dd::after {
     height: 100%;
     text-align: center;
 }
+.barMatrixMax {
+    width: 20rem;
+    background-color: transparent;
+}
+#barMatrixCur {
+    background-color: green;
+    width: 60%;
+    height: 100%;
+    text-align: center;
+}
 .monitors .monitor {
   text-align: center;
   color: black;

--- a/template.json
+++ b/template.json
@@ -429,6 +429,14 @@
 						"s": 0,
 						"d": 0,
 						"f": 0
+					},
+					"monitor": {
+						"base": 0,
+						"mod": 0,
+						"modString": "",
+						"value": 0,
+						"dmg": 0,
+						"max": 0
 					}
 				}
 			}

--- a/templates/dialog/configurable-roll-dialog.html
+++ b/templates/dialog/configurable-roll-dialog.html
@@ -93,6 +93,11 @@
         <td style="text-align:right">{{localize "shadowrun6.roll.wilddie"}}</td>
         <td><input type="checkbox" name="useWildDie" {{checked data.useWildDie}} /></td>
     	</tr>
+      <tr>
+        <td colspan="5"></td>
+        <td style="text-align:right">{{localize "shadowrun6.roll.matrix-modifier"}}</td>
+        <td><input type="checkbox" id="useMatrixModifier" {{checked data.useMatrixModifier}} /></td>
+      </tr>
     </table>
 
     <div class="hidden"> {{!-- hidden for js to still work --}}

--- a/templates/parts/monitors.html
+++ b/templates/parts/monitors.html
@@ -63,5 +63,22 @@
 			</td>
 		</tr>
 		{{/iff}}
+		{{#if (and system.persona (ne system.persona.monitor.max 0))}}
+		<tr>
+			<td class="centered"><img src="systems/shadowrun6-eden/images/all-seeing-eye.webp" style="border: 0px; height: 25px; width: 25px;" /></td>
+			<td><label title="{{localize 'shadowrun6.monitor.matrix'}}">{{localize 'shadowrun6.monitor.matrix'}}</label></td>
+			<td class="centered">
+				<input name="matrixMonitorDmg" data-field="system.persona.monitor.dmg" class="centered health-matrix" type="number" value="{{system.persona.monitor.dmg}}" data-dtype="Number" id="dataMatrixCur">
+			</td>
+			<td class="barMatrixMax">
+				<div style="width: 300px;">
+					<div style="position: relative; z-index: 1; border: solid black 1px;">
+						<div id="barMatrixCur" style="background-color: #00ff32; width: 78%;">&nbsp</div>
+						<div id="barMatrixBoxes" class="monitor"></div>
+					</div>
+				</div>
+			</td>
+		</tr>
+		{{/if}}
 	</tbody>
 </table>

--- a/templates/parts/monitors.html
+++ b/templates/parts/monitors.html
@@ -63,7 +63,7 @@
 			</td>
 		</tr>
 		{{/iff}}
-		{{#if (and system.persona (ne system.persona.monitor.max 0))}}
+		{{#if (and system.persona (gt system.persona.monitor.max 0))}}
 		<tr>
 			<td class="centered"><img src="systems/shadowrun6-eden/images/all-seeing-eye.webp" style="border: 0px; height: 25px; width: 25px;" /></td>
 			<td><label title="{{localize 'shadowrun6.monitor.matrix'}}">{{localize 'shadowrun6.monitor.matrix'}}</label></td>

--- a/templates/parts/monitors.html
+++ b/templates/parts/monitors.html
@@ -73,7 +73,7 @@
 			<td class="barMatrixMax">
 				<div style="width: 300px;">
 					<div style="position: relative; z-index: 1; border: solid black 1px;">
-						<div id="barMatrixCur" style="background-color: #00ff32; width: 78%;">&nbsp</div>
+						<div id="barMatrixCur" style="background-color: rgb(0 200 50); width: 78%;">&nbsp</div>
 						<div id="barMatrixBoxes" class="monitor"></div>
 					</div>
 				</div>


### PR DESCRIPTION
Add a matrix monitor to the player and npc character sheet.
The matrix monitor is only displayed if at least on matrix device is enabled.
The damage is applied to the cyberdeck or if no cyberdeck is used to the first matrix device used.

<img width="1525" height="789" alt="image" src="https://github.com/user-attachments/assets/9a5a927d-8980-4310-bc5a-f5117e3b9bc8" />

It also work as a bar on the token:
<img width="764" height="515" alt="image" src="https://github.com/user-attachments/assets/df20b702-6a9c-493c-af26-ee85174dab0a" />
