### PR TITLE
Fix Ammo # field width on the ActorSheet

### DIFF
--- a/templates/parts/section-ammo.html
+++ b/templates/parts/section-ammo.html
@@ -11,7 +11,7 @@
 		{{#iff item.system.type '==' "AMMUNITION"}}
        	<tr class="item" data-item-id="{{this.id}}"  title="{{item.system.description}}">
        		<td style="margin-right: 1rem"><label class="item-name draggable" data-uuid="{{item.uuid}}" data-skill="{{id}}">{{item.name}}</label></td>
-         	<td><input name="ammoCount{{id}}" class="centered box" type="text" data-item-id="{{this.id}}" data-field="system.count" type="text" value="{{item.system.count}}" data-dtype="Number" style="width: 1.5em" /></td>
+         	<td><input name="ammoCount{{id}}" class="centered box" type="text" data-item-id="{{this.id}}" data-field="system.count" type="text" value="{{item.system.count}}" data-dtype="Number" style="width: 2.5em" /></td>
 			<td style="width: 15%; text-align: right">
 				<a class="item-control item-edit" title='{{localize 'shadowrun6.label.edit' }}'><i class="fas fa-edit"></i></a>
 				<a class="item-control item-delete" title='{{localize 'shadowrun6.label.delete' }}'><i class="fas fa-trash"></i></a>

--- a/templates/parts/section-bodyware.html
+++ b/templates/parts/section-bodyware.html
@@ -48,6 +48,8 @@
        	<tr>
 			<td colspan="5">
 				<div class="collapsible-content closed" style="font-size: 0.8em;">
+					<div style="font-weight: bold;">{{ localize 'shadowrun6.label.accessories' }}</div>
+					<div>{{{item.enriched.accessories}}} &nbsp;</div>
 					<div style="font-weight: bold;">{{ localize 'shadowrun6.item.description' }}</div>
 					<div>{{{item.enriched.description}}} &nbsp;</div>
 				</div>


### PR DESCRIPTION
Hi!
- section Augmentation in Actor list don't see field Accessories  issue [#245](https://github.com/yjeroen/foundry-shadowrun6-eden/issues/245).
- section ammo in Actor list, the field with count is very narrow, two or more numbers don't fit in it

@yjeroen thank you for supporting this system