### PR TITLE
Gear mods under the arrow button

### DIFF
--- a/templates/parts/section-armor.html
+++ b/templates/parts/section-armor.html
@@ -38,8 +38,14 @@
        <tr>
          <td colspan="6">
          	<div class="collapsible-content closed" style="vertical-align: top">
-				<label>{{ localize 'shadowrun6.label.accessories' }}</label>
-				<div class="sheet-editor-readonly">{{{item.system.accessories}}}</div>
+				<div style="display: flex; align-items: center; vertical-align: middle;">{{ localize 'SR6.Item.mod.label.section' }}:</div>
+				{{#each (sort actor.items) as |itemmod id|}}
+				{{#iff itemmod.type '==' 'mod'}}
+				{{#iff itemmod.system.installedIn.id '==' item.id }}
+				<div style="margin: 0.3rem;"><a class="content-link" draggable="false" data-link="" data-uuid="{{itemmod.uuid}}" data-id="{{itemmod.uuid}}" data-type="Item">{{itemmod.name}}</a> &nbsp;</div>
+				{{/iff}}
+				{{/iff}}
+				{{/each}}
          	</div>
          </td>
        </tr>

--- a/templates/parts/section-bodyware.html
+++ b/templates/parts/section-bodyware.html
@@ -48,6 +48,14 @@
        	<tr>
 			<td colspan="5">
 				<div class="collapsible-content closed" style="font-size: 0.8em;">
+					 <div style="font-weight: bold;">{{ localize 'SR6.Item.mod.label.section' }}</div>
+			   		 {{#each (sort actor.items) as |itemmod id|}}
+			   		 {{#iff itemmod.type '==' 'mod'}}
+			   		 {{#iff itemmod.system.installedIn.id '==' item.id }}
+			   		 <div style="margin: 0.5rem;"><a class="content-link" draggable="false" data-link="" data-uuid="{{itemmod.uuid}}" data-id="{{itemmod.uuid}}" data-type="Item">{{itemmod.name}}</a> &nbsp;</div>
+			   		 {{/iff}}
+			   		 {{/iff}}
+			   		 {{/each}}
 					<div style="font-weight: bold;">{{ localize 'shadowrun6.item.description' }}</div>
 					<div>{{{item.enriched.description}}} &nbsp;</div>
 				</div>

--- a/templates/parts/section-gear.html
+++ b/templates/parts/section-gear.html
@@ -18,7 +18,7 @@
 		{{#if (eq item.system.type ../geartype) }}
 		<tr class="item list-item" data-item-id="{{item.id}}">
        	<td style="margin-right: 1rem; width: 0.7em;">
-		{{#if item.system.accessories }}
+		{{#if item.system.description }}
        	<button type="button" name="collapseGear{{id}}" class="collapsible closed" data-item-id="{{this.id}}">+</button>
        	{{else}}
        	<button type="button" name="collapseGear{{id}}" class="collapsible closed empty" data-item-id="{{this.id}}">+</button>
@@ -47,9 +47,15 @@
        <tr>
          <td colspan="5">
          	<div class="collapsible-content closed" style="font-size: 0.8em;">
-        	   <div style="font-weight: bold;">{{ localize 'shadowrun6.label.accessories' }}</div>
-			   <div>{{{item.enriched.accessories}}} &nbsp;</div>
-        	   <div style="font-weight: bold;">{{ localize 'shadowrun6.item.description' }}</div>
+        	   <div style="font-weight: bold;">{{ localize 'SR6.Item.mod.label.section' }}</div>
+			   {{#each (sort actor.items) as |itemmod id|}}
+			   {{#iff itemmod.type '==' 'mod'}}
+			   {{#iff itemmod.system.installedIn.id '==' item.id }}
+			   <div style="margin: 0.5rem;"><a class="content-link" draggable="false" data-link="" data-uuid="{{itemmod.uuid}}" data-id="{{itemmod.uuid}}" data-type="Item">{{itemmod.name}}</a> &nbsp;</div>
+			   {{/iff}}
+			   {{/iff}}
+			   {{/each}}
+			   <div style="font-weight: bold;">{{ localize 'shadowrun6.item.description' }}</div>
 			   <div>{{{item.enriched.description}}} &nbsp;</div>
          	</div>
          </td>

--- a/templates/parts/section-weapons.html
+++ b/templates/parts/section-weapons.html
@@ -15,7 +15,7 @@
                 <label class="item-name draggable" data-uuid="{{item.uuid}}" data-skill="{{id}}">{{item.name}}</label>
             </td>
             <td style="width: 10%"><label class="middle-column important-column">{{item.system.dmgDef}}</label></td>
-            <td style="width: 15%"><label class="middle-column" >{{{attackrating item.calculatedAttackRating}}}</label></td>
+            <td style="width: 15%"><label class="middle-column" >{{{attackrating item.calculated.attackRating}}}</label></td>
             <td style="width: 15%; text-align: right; vertical-align: middle; white-space: nowrap;">
                 {{#iff item.system.ammocap '>' 0}}
                 {{item.system.ammocount}}/{{item.system.ammocap}}
@@ -23,7 +23,7 @@
                 {{/iff}}
             </td>
             <td class="skill-pool" style="width: 15%; text-align: right;">
-         	    <label class="item-pool" data-skill="{{item.system.skill}}" data-skillspec="{{item.system.skillSpec}}">{{add item.system.pool item.system.modes.dicePoolMod}}</label>
+         	    <label class="item-pool" data-skill="{{item.system.skill}}" data-skillspec="{{item.system.skillSpec}}">{{item.system.pool}}</label>
          	    <a class="item-control weapon-roll" data-uuid="{{item.uuid}}" data-skill="{{item.system.skill}}" data-item-id="{{this.id}}" data-defend-with="physical" title="{{localize (concat "skill." item.system.skill)}}"><i class="fas fa-dice-six"></i></a>
             </td>
             <td style="width: 10%; text-align: right">
@@ -38,8 +38,14 @@
                     <table>
                         <tr>
                             <td>
-                                <label>{{ localize 'shadowrun6.label.accessories' }}</label>
-                                <div class="sheet-editor-readonly">{{{item.system.accessories}}}</div>
+                                <div style="display: flex; align-items: center; vertical-align: middle;">{{ localize 'SR6.Item.mod.label.section' }}:</div>
+                                {{#each (sort actor.items) as |itemmod id|}}
+                                {{#iff itemmod.type '==' 'mod'}}
+                                {{#iff itemmod.system.installedIn.id '==' item.id }}
+                                <div style="margin: 0.3rem;"><a class="content-link" draggable="false" data-link="" data-uuid="{{itemmod.uuid}}" data-id="{{itemmod.uuid}}" data-type="Item">{{itemmod.name}}</a> &nbsp;</div>
+                                {{/iff}}
+                                {{/iff}}
+                                {{/each}}
                             </td>
                         </tr>
                         <tr>
@@ -81,10 +87,10 @@
                 <label class="item-name draggable" data-uuid="{{item.uuid}}" data-skill="{{id}}">{{item.name}}</label>
             </td>
             <td style="width: 10%"><label class="middle-column important-column">{{item.system.dmgDef}}</label></td>
-            <td style="width: 15%"><label class="middle-column" >{{{attackrating item.calculatedAttackRating}}}</label></td>
+            <td style="width: 15%"><label class="middle-column" >{{{attackrating item.calculated.attackRating}}}</label></td>
             <td style="width: 15%"></td>
             <td class="skill-pool" style="width: 15%; text-align: right;">
-                <label class="item-pool" data-skill="{{item.system.skill}}">{{add item.system.pool item.system.modes.dicePoolMod}}</label>
+                <label class="item-pool" data-skill="{{item.system.skill}}">{{item.system.pool}}</label>
                 <a class="item-control weapon-roll" data-uuid="{{item.uuid}}" data-skill="{{item.system.skill}}" data-item-id="{{this.id}}" title="{{localize (concat "skill." item.system.skill)}}"><i class="fas fa-dice-six"></i></a>
             </td>
             <td style="width: 10%; text-align: right">
@@ -98,8 +104,14 @@
                     <table>
                         <tr>
                             <td>
-                                <label>{{ localize 'shadowrun6.label.accessories' }}</label>
-                                <div class="sheet-editor-readonly">{{{item.system.accessories}}}</div>
+                                <div style="display: flex; align-items: center; vertical-align: middle;">{{ localize 'SR6.Item.mod.label.section' }}:</div>
+                                {{#each (sort actor.items) as |itemmod id|}}
+                                {{#iff itemmod.type '==' 'mod'}}
+                                {{#iff itemmod.system.installedIn.id '==' item.id }}
+                                <div style="margin: 0.3rem;"><a class="content-link" draggable="false" data-link="" data-uuid="{{itemmod.uuid}}" data-id="{{itemmod.uuid}}" data-type="Item">{{itemmod.name}}</a> &nbsp;</div>
+                                {{/iff}}
+                                {{/iff}}
+                                {{/each}}
                             </td>
                         </tr>
                         <tr>
@@ -147,7 +159,7 @@
                 <label class="middle-column important-column">{{item.system.dmgDef}}</label>
             </td>
             <td style="width: 15%">
-                <label class="middle-column" >{{{attackrating item.calculatedAttackRating}}}</label>
+                <label class="middle-column" >{{{attackrating item.calculated.attackRating}}}</label>
             </td>
             <td style="width: 15%; text-align: right; vertical-align: middle; white-space: nowrap;">
                 {{#iff item.system.ammocap '>' 0}}
@@ -156,7 +168,7 @@
                 {{/iff}}
             </td>
             <td class="skill-pool" style="width: 15%; text-align: right;">
-                <label class="item-pool" data-skill="{{item.system.skill}}">{{add item.system.pool item.system.modes.dicePoolMod}}</label>
+                <label class="item-pool" data-skill="{{item.system.skill}}">{{item.system.pool}}</label>
                 <a class="item-control weapon-roll" data-uuid="{{item.uuid}}" data-skill="{{item.system.skill}}" data-item-id="{{this.id}}" title="{{localize (concat "skill." item.system.skill)}}"><i class="fas fa-dice-six"></i></a>
             </td>
             <td style="width: 10%; text-align: right">
@@ -170,8 +182,14 @@
                     <table>
                         <tr>
                             <td>
-                                <label>{{ localize 'shadowrun6.label.accessories' }}</label>
-                                <div class="sheet-editor-readonly">{{{item.system.accessories}}}</div>
+                                <div style="display: flex; align-items: center; vertical-align: middle;">{{ localize 'SR6.Item.mod.label.section' }}:</div>
+                                {{#each (sort actor.items) as |itemmod id|}}
+                                {{#iff itemmod.type '==' 'mod'}}
+                                {{#iff itemmod.system.installedIn.id '==' item.id }}
+                                <div style="margin: 0.3rem;"><a class="content-link" draggable="false" data-link="" data-uuid="{{itemmod.uuid}}" data-id="{{itemmod.uuid}}" data-type="Item">{{itemmod.name}}</a> &nbsp;</div>
+                                {{/iff}}
+                                {{/iff}}
+                                {{/each}}
                             </td>
                         </tr>
                         <tr>


### PR DESCRIPTION
@yjeroen Hi

I added a gear mods section under the arrow button. I made them links to objects to make it easy to open and read/edit the description. BecauseIt's not very convenient to open the Edit menu every time to see all installed mods )

Unfortunately, due to my limited experience and the complex structure of the character sheet, I was unable to link the arrow button color to the presence of modifications on the item. I think this connection is better than linking it to the description field. I also couldn't make conditions to hide the gear mods title if the modification list is empty.

<img width="1154" height="810" alt="image" src="https://github.com/user-attachments/assets/499900da-d80d-4e0a-bf18-eb7de3e33c38" />


Since this is only a visual change, I don't know what can be tested. I tried creating a player and pawn sheet, and the modifications are visible in both. Copying and importing to and from the compendium doesn't change the modification list. All of this was tested after the final commit and sync with the main project's main branch.